### PR TITLE
Fix/move save more retry

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -39,7 +39,7 @@ def test_request_exception_backoff_retry_mocked():
     ) as progress:
         # configure the system so that it does not produce debugging output
         debug_level = debug.DebugLevel.ERROR
-        console, _ = configure.setup(debug_level)
+        _, _ = configure.setup(debug_level)
         # define a URL that can be interacted with in a mocked fashion; importantly,
         # this test case is using responses and thus there is no actual interaction
         # with the GitHub API and no network transmission at all

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -15,6 +15,63 @@ from workknow import request
 
 
 @responses.activate
+def test_request_exception_backoff_retry_mocked_No_Error():
+    """Check that a mocked request to an API does not fail and it handles correctly."""
+    github_authentication = (
+        constants.github.User,
+        request.get_github_personal_access_token(),
+    )
+    github_params = {
+        constants.github.User_Agent: constants.workknow.Name,
+        constants.github.Per_Page: constants.github.Per_Page_Maximum,
+    }
+    with Progress(
+        constants.progress.Task_Format,
+        BarColumn(),
+        constants.progress.Percentage_Format,
+        constants.progress.Completed,
+        "•",
+        TimeElapsedColumn(),
+        "elapsed",
+        "•",
+        TimeRemainingColumn(),
+        "remaining",
+    ) as progress:
+        # configure the system so that it does not produce debugging output
+        debug_level = debug.DebugLevel.ERROR
+        _, _ = configure.setup(debug_level)
+        # define a URL that can be interacted with in a mocked fashion; importantly,
+        # this test case is using responses and thus there is no actual interaction
+        # with the GitHub API and no network transmission at all
+        github_api_url = "https://api.github.com/repos/home-assistant/core/actions/runs"
+        # define the response that the mocked API will return for al interactions
+        #
+        # note that this test case is only ensuring that an exception is not thrown
+        # and thus the status code is not especially useful in this context
+        responses.add(
+            responses.GET,
+            github_api_url,
+            json={"message": "server success"},
+            status=200,
+        )
+        # attempt to make a request from the mocked GitHub API; since this
+        # will always result in failure this will cause the exponential back-off
+        # and retry mechanism to start working until the maximum number of retries
+        (
+            valid,
+            total_retry_count,
+            total_retry_time,
+            response,
+        ) = request.request_with_caution(
+            github_api_url, github_params, github_authentication, progress, 2
+        )
+        assert valid is True
+        assert response is not None
+        assert total_retry_count == 0
+        assert total_retry_time == 0
+
+
+@responses.activate
 def test_request_exception_backoff_retry_mocked_HTTPError():
     """Check that a mocked request to an API fails and handles correctly."""
     github_authentication = (
@@ -101,7 +158,9 @@ def test_request_exception_backoff_retry_mocked_ChunkedEcodingError():
         responses.add(
             responses.GET,
             github_api_url,
-            body=requests.exceptions.ChunkedEncodingError("requests.exceptions.ChunkedEncodingError"),
+            body=requests.exceptions.ChunkedEncodingError(
+                "requests.exceptions.ChunkedEncodingError"
+            ),
         )
         # attempt to make a request from the mocked GitHub API; since this
         # will always result in failure this will cause the exponential back-off

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,10 +1,70 @@
 """Tests for the request module."""
 
+import requests
 import responses
 
+from rich.progress import BarColumn
+from rich.progress import Progress
+from rich.progress import TimeRemainingColumn
+from rich.progress import TimeElapsedColumn
+
 from workknow import configure
+from workknow import constants
 from workknow import debug
 from workknow import request
+
+
+@responses.activate
+def test_request_exception_backoff_retry_mocked():
+    """Check that a mocked request to an API fails and handles correctly."""
+    github_authentication = (
+        constants.github.User,
+        request.get_github_personal_access_token(),
+    )
+    github_params = {
+        constants.github.User_Agent: constants.workknow.Name,
+        constants.github.Per_Page: constants.github.Per_Page_Maximum,
+    }
+    with Progress(
+        constants.progress.Task_Format,
+        BarColumn(),
+        constants.progress.Percentage_Format,
+        constants.progress.Completed,
+        "•",
+        TimeElapsedColumn(),
+        "elapsed",
+        "•",
+        TimeRemainingColumn(),
+        "remaining",
+    ) as progress:
+        # configure the system so that it does not produce debugging output
+        debug_level = debug.DebugLevel.ERROR
+        console, _ = configure.setup(debug_level)
+        # define a URL that can be interacted with in a mocked fashion; importantly,
+        # this test case is using responses and thus there is no actual interaction
+        # with the GitHub API and no network transmission at all
+        github_api_url = "https://api.github.com/repos/home-assistant/core/actions/runs"
+        # define the response that the mocked API will return for al interactions
+        responses.add(
+            responses.GET,
+            github_api_url,
+            body=requests.exceptions.HTTPError("requests.exceptions.HTTPError"),
+        )
+        # attempt to download the JSON data from the mocked GitHub API; since this
+        # will always result in failure this will cause the exponential back-off
+        # and retry mechanism to start working until the maximum number of retries
+        (
+            valid,
+            total_retry_count,
+            total_retry_time,
+            response,
+        ) = request.request_with_caution(
+            github_api_url, github_params, github_authentication, progress, 2
+        )
+        assert valid is False
+        assert response is None
+        assert total_retry_count == 2
+        assert total_retry_time == (1 + 2)
 
 
 @responses.activate

--- a/workknow/main.py
+++ b/workknow/main.py
@@ -271,9 +271,7 @@ def download(
                     console.print(
                         f":sparkles: Saving a Zip file of all results in the directory {str(results_dir).strip()}"
                     )
-                    results_file_list = files.create_results_zip_file_list(
-                        results_dir
-                    )
+                    results_file_list = files.create_results_zip_file_list(results_dir)
                     files.create_results_zip_file(results_dir, results_file_list)
             else:
                 console.print()

--- a/workknow/request.py
+++ b/workknow/request.py
@@ -222,7 +222,6 @@ def request_with_caution(
             running_sleep_time_in_seconds = (
                 running_sleep_time_in_seconds + sleep_time_in_seconds
             )
-            print(running_sleep_time_in_seconds)
             request_retries_count = request_retries_count + 1
     valid = False
     if response is not None:

--- a/workknow/request.py
+++ b/workknow/request.py
@@ -235,15 +235,20 @@ def request_json_from_github_with_caution(
     github_authentication,
     progress,
     maximum_retries: int = constants.github.Maximum_Request_Retries,
-) -> Tuple[bool, int, int, requests.Response]:
+) -> Tuple[bool, int, int, Union[requests.Response, None]]:
     """Request data from the GitHub API in a cautious fashion, checking error codes and waiting when needed."""
     # use requests to access the GitHub API with:
     # --> provided GitHub URL that accesses a project's GitHub Actions log
     # --> the parameters that currently specify the page limit and will specify the page
     # --> the GitHub authentication information with the personal access token
-    response = requests.get(
-        github_api_url, params=github_params, auth=github_authentication
+    # response = requests.get(
+    #     github_api_url, params=github_params, auth=github_authentication
+    # )
+    (valid, request_retries_count, request_sleep_time, response) = request_with_caution(
+        github_api_url, github_params, github_authentication, progress, maximum_retries
     )
+    if not valid:
+        return (valid, request_retries_count, request_sleep_time, None)
     # start the retry count at 1 so that the first calculation of an exponential
     # back-off works as expected; all retry operations will use <= to the maximum
     # so as to ensure that the number of retries goes to the maximum value

--- a/workknow/request.py
+++ b/workknow/request.py
@@ -303,9 +303,14 @@ def request_json_from_github_with_caution(
             progress.console.print(
                 f"{constants.markers.Tab}{constants.markers.Tab}...Attempt {response_retries_count} to access GitHub API at {github_api_url}"
             )
-            response = requests.get(
-                github_api_url, params=github_params, auth=github_authentication
+            # response = requests.get(
+            #     github_api_url, params=github_params, auth=github_authentication
+            # )
+            (valid, request_retries_count, request_sleep_time, response) = request_with_caution(
+                github_api_url, github_params, github_authentication, progress, maximum_retries
             )
+            if not valid:
+                return (valid, request_retries_count, request_sleep_time, None)
             # extract the current response code for check in next iteration of loop
             current_response_status_code = response.status_code
             # indicate that another retry has taken place

--- a/workknow/request.py
+++ b/workknow/request.py
@@ -277,14 +277,14 @@ def request_json_from_github_with_caution(
     # in my experience with using WorkKnow, these are two common status codes:
     # 200: everything worked and JSON response is available
     # 502: error on the server and a error-message JSON contains no data
-    current_response_status_code = response.status_code
+    current_response_status_code = response.status_code  # type: ignore
     # indicate that an attempt at a retry has not yet happened
     attempted_retries = False
     running_sleep_time_in_seconds = 0
     # the response code indicates that there was no success for this
     # interaction with the GitHub API and thus we must retry in an
     # exponential back-off fashion up to a maximum number of retries
-    if response.status_code != constants.github.Success_Response:
+    if response.status_code != constants.github.Success_Response:  # type: ignore
         progress.console.print()
         progress.console.print(
             f":grimacing_face: Unable to access GitHub API at {github_api_url} due to error code {current_response_status_code}"
@@ -341,7 +341,7 @@ def request_json_from_github_with_caution(
             if not valid:
                 return (valid, request_retries_count, request_sleep_time, None)
             # extract the current response code for check in next iteration of loop
-            current_response_status_code = response.status_code
+            current_response_status_code = response.status_code  # type: ignore
             # indicate that another retry has taken place
             response_retries_count = response_retries_count + 1
     # since the loop will terminate as soon as there is a successful response code,
@@ -426,8 +426,8 @@ def request_json_from_github(
         if valid:
             # extract the JSON document (it is a dict) and then extract from that the workflow runs list;
             # finally, append the list of workflow runs to the running list of response details
-            json_responses.append(get_workflow_runs(response.json(), console))
-            logger.debug(response.headers)
+            json_responses.append(get_workflow_runs(response.json(), console))  # type: ignore
+            logger.debug(response.headers)  # type: ignore
             # pagination in GitHub Actions is 1-indexed (i.e., the first index is 1)
             # and thus the next page that we will need to extract (if needed) is 2
             page = constants.github.Page_Start
@@ -436,13 +436,13 @@ def request_json_from_github(
             rate_limit_dict = get_rate_limit_details()
             get_rate_limit_wait_time_and_wait(rate_limit_dict)
             # extract the index of the last page in order to support progress bar creation
-            last_page_index = extract_last_page(response.links)
+            last_page_index = extract_last_page(response.links)  # type: ignore
             # continue to extract data from the pages as long as the "next" field is evident
             download_pages_task = progress.add_task(
                 "Complete Download", total=last_page_index - 1
             )
             # there is another page and thus WorkKnow should iterate and download it
-            while constants.github.Next in response.links.keys():
+            while constants.github.Next in response.links.keys():  # type: ignore
                 # update the "page" variable in the URL to go to the next page
                 # otherwise, make sure to use all of the same parameters as the first request
                 github_params[constants.github.Page] = str(page)
@@ -455,13 +455,13 @@ def request_json_from_github(
                 ) = request_json_from_github_with_caution(
                     github_api_url, github_params, github_authentication, progress
                 )
-                logger.debug(response.headers)
+                logger.debug(response.headers)  # type: ignore
                 # the response from the GitHub API was valid, which means that it either returned
                 # correctly the first time or, alternatively, waiting in an exponential back-off
                 # fashion ultimately resulted in the download completing with success
                 if valid:
                     # again extract the specific workflow runs list and append it to running response details
-                    json_responses.append(get_workflow_runs(response.json(), console))
+                    json_responses.append(get_workflow_runs(response.json(), console))  # type: ignore
                     # go to the next page in the pagination results list
                     page = page + 1
                     # check if the program is about to exceed GitHub's rate limit and then

--- a/workknow/request.py
+++ b/workknow/request.py
@@ -326,8 +326,17 @@ def request_json_from_github_with_caution(
             # response = requests.get(
             #     github_api_url, params=github_params, auth=github_authentication
             # )
-            (valid, request_retries_count, request_sleep_time, response) = request_with_caution(
-                github_api_url, github_params, github_authentication, progress, maximum_retries
+            (
+                valid,
+                request_retries_count,
+                request_sleep_time,
+                response,
+            ) = request_with_caution(
+                github_api_url,
+                github_params,
+                github_authentication,
+                progress,
+                maximum_retries,
             )
             if not valid:
                 return (valid, request_retries_count, request_sleep_time, None)


### PR DESCRIPTION
This pull request ensure that when the GitHub API throws an exception related to the `requests` module or `urllib3` that this does not cause the program to crash and instead it performs more retries and a back-off mechanism.